### PR TITLE
[receipt] 상점 이용 내역 조회 API

### DIFF
--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptMapper.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptMapper.kt
@@ -1,0 +1,22 @@
+package gogo.gogoshop.domain.shop.receipt.application
+
+import gogo.gogoshop.domain.shop.receipt.application.dto.ShopTicketReceiptDto
+import gogo.gogoshop.domain.shop.receipt.persistence.ShopReceipt
+import org.springframework.stereotype.Component
+
+@Component
+class ShopReceiptMapper {
+
+    fun map(shopReceipt: List<ShopReceipt>) =
+        shopReceipt.map { receipt ->
+            ShopTicketReceiptDto(
+                ticketPrice = receipt.ticketPrice,
+                ticketQuantity = receipt.ticketQauntity,
+                ticketType = receipt.ticketType,
+                purchaseDate = receipt.purchaseDate
+            )
+        }
+
+
+
+}

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptMapper.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptMapper.kt
@@ -1,5 +1,6 @@
 package gogo.gogoshop.domain.shop.receipt.application
 
+import gogo.gogoshop.domain.shop.receipt.application.dto.ReceiptResDto
 import gogo.gogoshop.domain.shop.receipt.application.dto.ShopTicketReceiptDto
 import gogo.gogoshop.domain.shop.receipt.persistence.ShopReceipt
 import org.springframework.stereotype.Component
@@ -16,6 +17,12 @@ class ShopReceiptMapper {
                 purchaseDate = receipt.purchaseDate
             )
         }
+
+    fun mapReceiptResDto(shopTicketReceiptDto: List<ShopTicketReceiptDto>, receiptCount: Int) =
+        ReceiptResDto(
+            count = receiptCount,
+            receipt = shopTicketReceiptDto
+        )
 
 
 

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptReader.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptReader.kt
@@ -1,0 +1,14 @@
+package gogo.gogoshop.domain.shop.receipt.application
+
+import gogo.gogoshop.domain.shop.receipt.persistence.ShopReceiptRepository
+import org.springframework.stereotype.Component
+
+@Component
+class ShopReceiptReader(
+    private val shopReceiptRepository: ShopReceiptRepository
+) {
+
+    fun read(shopId: Long, studentId: Long) =
+        shopReceiptRepository.findByShopIdAndStudentId(shopId, studentId)
+
+}

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptReader.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptReader.kt
@@ -11,4 +11,8 @@ class ShopReceiptReader(
     fun read(shopId: Long, studentId: Long) =
         shopReceiptRepository.findByShopIdAndStudentId(shopId, studentId)
 
+    fun readReceiptCount(shopId: Long, studentId: Long) =
+        shopReceiptRepository.countByShopIdAndStudentId(shopId, studentId)
+
+
 }

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptService.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptService.kt
@@ -1,0 +1,7 @@
+package gogo.gogoshop.domain.shop.receipt.application
+
+import gogo.gogoshop.domain.shop.receipt.application.dto.ReceiptResDto
+
+interface ShopReceiptService {
+    fun getShopReceipt(shopId: Long): ReceiptResDto
+}

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptServiceImpl.kt
@@ -1,0 +1,22 @@
+package gogo.gogoshop.domain.shop.receipt.application
+
+import gogo.gogoshop.domain.shop.receipt.application.dto.ReceiptResDto
+import gogo.gogoshop.global.util.UserContextUtil
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ShopReceiptServiceImpl(
+    private val shopReceiptReader: ShopReceiptReader,
+    private val shopReceiptMapper: ShopReceiptMapper,
+    private val userUtil: UserContextUtil
+): ShopReceiptService {
+
+    @Transactional(readOnly = true)
+    override fun getShopReceipt(shopId: Long): ReceiptResDto {
+        val student = userUtil.getCurrentStudent()
+        val shopReceiptList = shopReceiptReader.read(shopId, student.studentId)
+        val shopTicketReceiptDtoList = shopReceiptMapper.map(shopReceiptList)
+        return ReceiptResDto(shopTicketReceiptDtoList)
+    }
+}

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/ShopReceiptServiceImpl.kt
@@ -16,7 +16,9 @@ class ShopReceiptServiceImpl(
     override fun getShopReceipt(shopId: Long): ReceiptResDto {
         val student = userUtil.getCurrentStudent()
         val shopReceiptList = shopReceiptReader.read(shopId, student.studentId)
+        val receiptCount = shopReceiptReader.readReceiptCount(shopId, student.studentId)
         val shopTicketReceiptDtoList = shopReceiptMapper.map(shopReceiptList)
-        return ReceiptResDto(shopTicketReceiptDtoList)
+        val receiptResDto = shopReceiptMapper.mapReceiptResDto(shopTicketReceiptDtoList, receiptCount)
+        return receiptResDto
     }
 }

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/dto/ShopReceiptDto.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/dto/ShopReceiptDto.kt
@@ -1,7 +1,7 @@
 package gogo.gogoshop.domain.shop.receipt.application.dto
 
 import gogo.gogoshop.domain.shop.receipt.persistence.TicketType
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class ReceiptResDto(
     val receipt: List<ShopTicketReceiptDto>
@@ -11,5 +11,5 @@ data class ShopTicketReceiptDto(
     val ticketPrice: Int,
     val ticketQuantity: Int,
     val ticketType: TicketType,
-    val purchaseDate: LocalDate
+    val purchaseDate: LocalDateTime
 )

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/dto/ShopReceiptDto.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/dto/ShopReceiptDto.kt
@@ -4,6 +4,7 @@ import gogo.gogoshop.domain.shop.receipt.persistence.TicketType
 import java.time.LocalDateTime
 
 data class ReceiptResDto(
+    val count: Int,
     val receipt: List<ShopTicketReceiptDto>
 )
 

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/dto/ShopReceiptDto.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/application/dto/ShopReceiptDto.kt
@@ -1,0 +1,15 @@
+package gogo.gogoshop.domain.shop.receipt.application.dto
+
+import gogo.gogoshop.domain.shop.receipt.persistence.TicketType
+import java.time.LocalDate
+
+data class ReceiptResDto(
+    val receipt: List<ShopTicketReceiptDto>
+)
+
+data class ShopTicketReceiptDto(
+    val ticketPrice: Int,
+    val ticketQuantity: Int,
+    val ticketType: TicketType,
+    val purchaseDate: LocalDate
+)

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/persistence/ShopReceipt.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/persistence/ShopReceipt.kt
@@ -1,7 +1,7 @@
 package gogo.gogoshop.domain.shop.receipt.persistence
 
 import jakarta.persistence.*
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tbl_shop_receipt")
@@ -28,7 +28,7 @@ class ShopReceipt(
     val ticketType: TicketType,
 
     @Column(name = "purchase_date", nullable = false)
-    val purchaseDate: LocalDate
+    val purchaseDate: LocalDateTime
 ) {
 }
 

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/persistence/ShopReceiptRepository.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/persistence/ShopReceiptRepository.kt
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ShopReceiptRepository: JpaRepository<ShopReceipt, Long> {
     fun findByShopIdAndStudentId(shopId: Long, studentId: Long): List<ShopReceipt>
+    fun countByShopIdAndStudentId(shopId: Long, studentId: Long): Int
 }

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/persistence/ShopReceiptRepository.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/persistence/ShopReceiptRepository.kt
@@ -3,4 +3,5 @@ package gogo.gogoshop.domain.shop.receipt.persistence
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ShopReceiptRepository: JpaRepository<ShopReceipt, Long> {
+    fun findByShopIdAndStudentId(shopId: Long, studentId: Long): List<ShopReceipt>
 }

--- a/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/presentation/ShopReceiptController.kt
+++ b/src/main/kotlin/gogo/gogoshop/domain/shop/receipt/presentation/ShopReceiptController.kt
@@ -1,0 +1,22 @@
+package gogo.gogoshop.domain.shop.receipt.presentation
+
+import gogo.gogoshop.domain.shop.receipt.application.ShopReceiptService
+import gogo.gogoshop.domain.shop.receipt.application.dto.ReceiptResDto
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/shop/receipt")
+class ShopReceiptController(
+    private val shopReceiptService: ShopReceiptService
+) {
+
+    @GetMapping("/{shop_id}")
+    fun getReceipt(@PathVariable("shop_id") shopId: Long): ResponseEntity<ReceiptResDto> {
+        val response = shopReceiptService.getShopReceipt(shopId)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/gogo/gogoshop/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogoshop/global/config/SecurityConfig.kt
@@ -48,6 +48,7 @@ class SecurityConfig(
 
             // shop
             httpRequests.requestMatchers(HttpMethod.GET, "/shop/{stage_id}").hasAnyRole(Authority.USER.name)
+            httpRequests.requestMatchers(HttpMethod.GET, "/shop/receipt/{shop_id}").hasAnyRole(Authority.USER.name)
 
             httpRequests.anyRequest().denyAll()
         }


### PR DESCRIPTION
# 개요
* 스테이지에 존재하는 상점을 이용했을 경우 이용 내역을 조회할 수 있는 API를 개발하였습니다.(`/shop/receipt/{shop_id}`)

# 본문
* `USER` 권한을 가진 유저만 요청이 가능합니다.
* 상점을 이용하기 전에는 빈리스트가 반환되고, 상점을 이용하여 내역이 남게 되면 shopId와 studentId로 조회한 후 Json에서 receipt 안 리스트로 반환하게 개발하였습니다.